### PR TITLE
fix unit test: duplicate partiton column

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ jdk:
 install: true
 
 script:
-  - mvn clean install
+  - mvn clean package

--- a/pom.xml
+++ b/pom.xml
@@ -199,31 +199,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArguments>
-                        <Xlint:all/>
-                        <!-- bootstrap class path not set in conjunction with -source 1.7 -->
-                        <Xlint:-options/>
-                        <!-- serializable class ... has no definition of serialVersionUID -->
-                        <Xlint:-serial/>
-                        <!-- bad path element ".../repository/org/apache/derby/derby/10.10.2.0/derbyLocale_*.jar": no such file or directory -->
-                        <Xlint:-path/>
-                        <!--
-                        WALFile.java:[333,16] [deprecation] sync() in Syncable has been deprecated
-                        Apparently SuppressWarnings("deprecation") doesn't cover this on JDK 7
-                        -->
-                        <Xlint:-deprecation/>
-                        <!-- Needed for DataWriter.java because @SuppressWarnings("unchecked") doesn't cover this on JDK 7 -->
-                        <Xlint:-unchecked/>
-                        <Werror/>
-                    </compilerArguments>
-                    <showWarnings>true</showWarnings>
-                    <showDeprecation>false</showDeprecation>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.5.3</version>
                 <configuration>

--- a/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/parquet/HiveIntegrationParquetTest.java
@@ -160,9 +160,16 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     hdfsWriter.stop();
 
     Table table = hiveMetaStore.getTable(hiveDatabase, TOPIC);
+    String partitionFieldName = connectorConfig.getString(
+            PartitionerConfig.PARTITION_FIELD_NAME_CONFIG
+    );
 
     List<String> expectedColumnNames = new ArrayList<>();
     for (Field field : schema.fields()) {
+      // ignore partition field
+      if (field.name().equals(partitionFieldName)) {
+        continue;
+      }
       expectedColumnNames.add(field.name());
     }
 
@@ -172,9 +179,7 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
     }
     assertEquals(expectedColumnNames, actualColumnNames);
 
-    String partitionFieldName = connectorConfig.getString(
-        PartitionerConfig.PARTITION_FIELD_NAME_CONFIG
-    );
+
     String directory1 = TOPIC + "/" + partitionFieldName + "=" + String.valueOf(16);
     String directory2 = TOPIC + "/" + partitionFieldName + "=" + String.valueOf(17);
     String directory3 = TOPIC + "/" + partitionFieldName + "=" + String.valueOf(18);
@@ -193,6 +198,10 @@ public class HiveIntegrationParquetTest extends HiveTestBase {
       for (int j = 0; j < 3; ++j) {
         List<String> result = new ArrayList<>();
         for (Field field : schema.fields()) {
+          // ignore partition field
+          if (field.name().equals(partitionFieldName)) {
+            continue;
+          }
           result.add(String.valueOf(records.get(i).get(field.name())));
         }
         expectedResults.add(result);


### PR DESCRIPTION
修复 https://github.com/xiachufang/kafka-connect-hdfs/pull/2 引入后，单元测试坏掉的情况。

相关 issue：https://github.com/confluentinc/kafka-connect-hdfs/issues/221

